### PR TITLE
Fix OSError message when importing CairoSvg

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,30 @@ Most common SVG tags are supported and others can easily be added by writing a s
 
 An interactive [Jupyter notebook](https://jupyter.org) widget, `drawSvg.widgets.DrawingWidget`, is included that can update drawings based on mouse events.
 
-# Prerequisites
-Cairo needs to be installed separately. See platform-specific [instructions for Linux, Windows, and macOS from Cairo.](https://www.cairographics.org/download/) Below are some examples for installing Cairo on Linux distributions and macOS.
+# Install
 
+drawSvg is available on PyPI:
 
+```
+$ pip3 install drawSvg
+```
+
+## Prerequisites
+
+Cairo needs to be installed separately. When Cairo is installed, drawSvg can output PNG or other image formats in addition to SVG. See platform-specific [instructions for Linux, Windows, and macOS from Cairo.](https://www.cairographics.org/download/) Below are some examples for installing Cairo on Linux distributions and macOS.
 
 **Ubuntu**
+
 ```
-sudo apt-get install libcairo2
+$ sudo apt-get install libcairo2
 ```
 
 **macOS**
 
 Using [homebrew](https://brew.sh/):
-```
-brew install cairo
-```
-
-# Install
-drawSvg is available on PyPI:
 
 ```
-$ pip3 install drawSvg
+$ brew install cairo
 ```
 
 # Examples

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ pip3 install drawSvg
 
 ## Prerequisites
 
-Cairo needs to be installed separately. When Cairo is installed, drawSvg can output PNG or other image formats in addition to SVG. See platform-specific [instructions for Linux, Windows, and macOS from Cairo.](https://www.cairographics.org/download/) Below are some examples for installing Cairo on Linux distributions and macOS.
+Cairo needs to be installed separately. When Cairo is installed, drawSvg can output PNG or other image formats in addition to SVG. See platform-specific [instructions for Linux, Windows, and macOS from Cairo](https://www.cairographics.org/download/). Below are some examples for installing Cairo on Linux distributions and macOS.
 
 **Ubuntu**
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ Most common SVG tags are supported and others can easily be added by writing a s
 
 An interactive [Jupyter notebook](https://jupyter.org) widget, `drawSvg.widgets.DrawingWidget`, is included that can update drawings based on mouse events.
 
+# Prerequisites
+Cairo needs to be installed separately. See platform-specific [instructions for Linux, Windows, and macOS from Cairo.](https://www.cairographics.org/download/) Below are some examples for installing Cairo on Linux distributions and macOS.
+
+
+
+**Ubuntu**
+```
+sudo apt-get install libcairo2
+```
+
+**macOS**
+
+Using [homebrew](https://brew.sh/):
+```
+brew install cairo
+```
+
 # Install
 drawSvg is available on PyPI:
 

--- a/drawSvg/raster.py
+++ b/drawSvg/raster.py
@@ -7,9 +7,12 @@ from .missing import MissingModule
 try:
     import cairosvg
 except OSError as e:
-    msg = e.args[0]
-    if msg.startswith("no library called \"cairo\" was found"):
-        msg = 'Cairo will need to be installed to rasterize images: See prerequisites section in `README` at https://github.com/cduck/drawSvg#prerequisites'
+    msg = (
+        'Failed to import CairoSVG. '
+        'drawSvg will be unable to output PNG or other raster image formats. '
+        'See https://github.com/cduck/drawSvg#prerequisites for more details.\n'
+        f'Original OSError: {e}'
+    )
     cairosvg = MissingModule(msg)
     warnings.warn(msg, RuntimeWarning)
 except ImportError:

--- a/drawSvg/raster.py
+++ b/drawSvg/raster.py
@@ -6,8 +6,10 @@ from .missing import MissingModule
 
 try:
     import cairosvg
-except OSError:
-    msg = 'Cairo will need to be installed to rasterize images: See prerequisites section in `README`'
+except OSError as e:
+    msg = e.args[0]
+    if msg.startswith("no library called \"cairo\" was found"):
+        msg = 'Cairo will need to be installed to rasterize images: See prerequisites section in `README` at https://github.com/cduck/drawSvg#prerequisites'
     cairosvg = MissingModule(msg)
     warnings.warn(msg, RuntimeWarning)
 except ImportError:

--- a/drawSvg/raster.py
+++ b/drawSvg/raster.py
@@ -11,12 +11,15 @@ except OSError as e:
         'Failed to import CairoSVG. '
         'drawSvg will be unable to output PNG or other raster image formats. '
         'See https://github.com/cduck/drawSvg#prerequisites for more details.\n'
-        f'Original OSError: {e}'
+        'Original OSError: {}'.format(e)
     )
     cairosvg = MissingModule(msg)
     warnings.warn(msg, RuntimeWarning)
-except ImportError:
-    msg = 'CairoSVG will need to be installed to rasterize images: Install with `pip3 install cairosvg`'
+except ImportError as e:
+    msg = (
+        'CairoSVG will need to be installed to rasterize images: Install with `pip3 install cairosvg`\n'
+        'Original ImportError: {}'.format(e)
+    )
     cairosvg = MissingModule(msg)
     warnings.warn(msg, RuntimeWarning)
 

--- a/drawSvg/raster.py
+++ b/drawSvg/raster.py
@@ -1,11 +1,16 @@
 
 import io
+import warnings
+from .missing import MissingModule
+
 
 try:
     import cairosvg
-except (ImportError, OSError):
-    import warnings
-    from .missing import MissingModule
+except OSError:
+    msg = 'Cairo will need to be installed to rasterize images: See prerequisites section in `README`'
+    cairosvg = MissingModule(msg)
+    warnings.warn(msg, RuntimeWarning)
+except ImportError:
     msg = 'CairoSVG will need to be installed to rasterize images: Install with `pip3 install cairosvg`'
     cairosvg = MissingModule(msg)
     warnings.warn(msg, RuntimeWarning)


### PR DESCRIPTION
## What is the change?
* Create separate catch block for OSError when Cairo, a non-Python module, is not installed
* Update README with prerequisites and instructions on installing Cairo

Fixes #4.

## Why is it needed?
When `drawSvg` imports `cairosvg` in [this line of code](https://github.com/cduck/drawSvg/blob/bab21b78cc0e4c01ebb4371f24ab36781bc4e8d2/drawSvg/raster.py#L5), it currently catches both ImportError and OSError in the same block. However, if a user's platform does not have Cairo, a non-Python module, installed, it will throw a misleading error message, telling the user to install `cairosvg` even though it is already installed and hiding the real cause of the error, namely that `Cairo` is not installed. This change fixes that misleading error message. 

## Tests
Operating system: macOS Mojave (10.14.6)
Python Version: 3.7.4 (default, July 8, 2019)
I'm using a virtual environment.

* Cairo and CairoSvg not installed
```
In [1]: import drawSvg
/Users/markbonicillo/Workplace/drawSvg/drawSvg/raster.py:16: RuntimeWarning: CairoSVG will need to be installed to rasterize images: Install with `pip3 install cairosvg`
  warnings.warn(msg, RuntimeWarning)
```

* CairoSvg installed, but not Cairo
```
In [1]: import drawSvg
/Users/markbonicillo/Workplace/drawSvg/drawSvg/raster.py:12: RuntimeWarning: Cairo will need to be installed to rasterize images: See prerequisites section in `README`
  warnings.warn(msg, RuntimeWarning)
```

* CairoSvg and Cairo both installed
```
In [1]: import drawSvg as draw

d = draw.Drawing(200, 100, origin='center')

d.append(draw.Lines(-80, -45,
                    70, -49,
                    95, 49,
                    -90, 40,
                    close=False,
            fill='#eeee00',
            stroke='black'))

d.append(draw.Rectangle(0,0,40,50, fill='#1248ff'))
d.append(draw.Circle(-40, -10, 30,
            fill='red', stroke_width=2, stroke='black'))

p = draw.Path(stroke_width=2, stroke='green',
              fill='black', fill_opacity=0.5)
p.M(-30,5)  # Start path at point (-30, 5)
p.l(60,30)  # Draw line to (60, 30)
p.h(-70)    # Draw horizontal line to x=-70
p.Z()       # Draw line to start
d.append(p)

d.append(draw.ArcLine(60,-20,20,60,270,
            stroke='red', stroke_width=5, fill='red', fill_opacity=0.2))
d.append(draw.Arc(60,-20,20,60,270,cw=False,
            stroke='green', stroke_width=3, fill='none'))
d.append(draw.Arc(60,-20,20,270,60,cw=True,
            stroke='blue', stroke_width=1, fill='black', fill_opacity=0.3))

d.setPixelScale(2)  # Set number of pixels per geometry unit
#d.setRenderSize(400,200)  # Alternative to setPixelScale
d.saveSvg('example.svg')
d.savePng('example.png')

# Display in iPython notebook
d.rasterize()  # Display as PNG
d  # Display as SVG

Out[4]: <drawSvg.drawing.Drawing at 0x1177cad10>
```