### PR TITLE
Adding missing import to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ with draw.animate_jupyter(draw_frame, delay=0.05) as anim:
 ### Asynchronous Animation in Jupyter
 ```python
 # Jupyter cell 1:
+import drawSvg as draw
 from drawSvg.widgets import AsyncAnimation
 widget = AsyncAnimation(fps=10)
 widget


### PR DESCRIPTION
Copy pasted the last example in the readme to Jupyter notebook to try it and had an import error. Easy enough for a user to fix, but threw it in a pull request.

```python---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
~\anaconda3\lib\site-packages\drawSvg\widgets\drawing_widget.py in _receive_msg(self, _, content, buffers)
     79             if callbacks:
     80                 if name == 'timed':
---> 81                     self._call_handlers(callbacks, content)
     82                 else:
     83                     self._call_handlers(callbacks, content.get('x'),

~\anaconda3\lib\site-packages\drawSvg\widgets\drawing_widget.py in _call_handlers(self, callback_list, *args, **kwargs)
    158     def _call_handlers(self, callback_list, *args, **kwargs):
    159         for callback in callback_list:
--> 160             callback(self, *args, **kwargs)

~\anaconda3\lib\site-packages\drawSvg\widgets\async_animation.py in timed(self, info)
    106         def timed(self, info):
    107             secs = time.monotonic() - self._start_time
--> 108             self.drawing = self.draw_frame(secs)
    109             self._last_secs = secs
    110 

<ipython-input-2-d8e19cef2e10> in draw_frame(secs)
      4 def draw_frame(secs=0):
      5     # Draw something...
----> 6     d = draw.Drawing(100, 40)
      7     d.append(draw.Text(global_variable, 20, 0, 10))
      8     d.append(draw.Text('{:0.1f}'.format(secs), 20, 30, 10))

NameError: name 'draw' is not defined`