### PR TITLE
Get all widget parent ids on click

### DIFF
--- a/drawsvg/widgets/drawing_javascript.py
+++ b/drawsvg/widgets/drawing_javascript.py
@@ -71,6 +71,17 @@ define('drawingview', ['@jupyter-widgets/base'], function(widgets) {
             var svg_pt = this.cursor_point.matrixTransform(
                             this.svg_view.getScreenCTM().inverse());
 
+            var target_parents = [];
+            var target = e.target;
+            while(target && target != this.svg_view)
+            {
+                console.log(target, target.id);
+                if(target.id) {
+                    target_parents.push(target.id);
+                }
+                target = target.parentNode;
+            }
+
             this.send({
                 name: name,
                 x: svg_pt.x,
@@ -88,6 +99,7 @@ define('drawingview', ['@jupyter-widgets/base'], function(widgets) {
                 movementY: e.movementY,
                 timeStamp: e.timeStamp,
                 targetId: e.target ? e.target.id : null,
+                targetParentIds: target_parents,
                 currentTargetId: e.currentTarget ? e.currentTarget.id : null,
                 relatedTargetId: e.relatedTarget ? e.relatedTarget.id : null,
             });

--- a/drawsvg/widgets/drawing_javascript.py
+++ b/drawsvg/widgets/drawing_javascript.py
@@ -75,8 +75,7 @@ define('drawingview', ['@jupyter-widgets/base'], function(widgets) {
             var target = e.target;
             while(target && target != this.svg_view)
             {
-                console.log(target, target.id);
-                if(target.id) {
+                if (target.id) {
                     target_parents.push(target.id);
                 }
                 target = target.parentNode;


### PR DESCRIPTION
There is probably a much better way of doing this (and it might already be in the library), but I thought I would upload a PR for discussion.

I was finding the "targetId" less useful than I hoped, as it is often empty, unless I give an Id to every single element. In practice I usually want the first named parent which has an Id, so I added a quick function to get that.