### PR TITLE
setup: Bump numpy version to equivalent to 2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,17 +34,17 @@ setup(
     extras_require = {
         'raster': [
             'cairoSVG~=2.3',
-            'numpy~=1.16',
+            'numpy~=2.1',
             'imageio~=2.5',
             'imageio_ffmpeg~=0.4',
         ],
         'color': [
             'pwkit~=1.0',
-            'numpy~=1.16',
+            'numpy~=2.1',
         ],
         'all': [
             'cairoSVG~=2.3',
-            'numpy~=1.16',
+            'numpy~=2.1',
             'imageio~=2.5',
             'imageio_ffmpeg~=0.4',
             'pwkit~=1.0',


### PR DESCRIPTION
On further investigation, it appears numpy usage is limited to parts of the API that have not changed since 1.16, so I forked and updated the dependency and validated it was now working (at least as far as generating an SVG and then rasterising it to PNG).

This change does mean that the oldest version of Python this can be compatible with is Python 3.10, while the older dependency, `~= 1.16` seems to allow compatibility with Python 2.7 to 3.12, so please feel free to reject this PR.

Closes #143 